### PR TITLE
mk_pkg_table: Fix column position for GHC 7.10.*

### DIFF
--- a/library-versions/mk_pkg_table.hs
+++ b/library-versions/mk_pkg_table.hs
@@ -60,7 +60,7 @@ main = do
         allgvs  = S.toDescList $ M.keysSet vs
 
     let hdr = "<tr><th>" ++ cells ++ "</th></tr>"
-          where cells = intercalate "</th> <th>" $ (" " : [ "<b>" <> showGhcRelease v <> "</b>" | v <- allgvs ]) ++ [""]
+          where cells = intercalate "</th> <th>" (" " : [ "<b>" <> showGhcRelease v <> "</b>" | v <- allgvs ])
     putStrLn "<table>"
     putStrLn hdr
 


### PR DESCRIPTION
Previously the ordering was `7.2.* | 7.10.* | 7.0.*` due to
lexicographic string sorting.