### PR TITLE
Add script that finds the Win32 version for a given GHC release

### DIFF
--- a/library-versions/README.mkd
+++ b/library-versions/README.mkd
@@ -10,7 +10,6 @@ of the GHC wiki.
 1. First dump the compiler's global package database: `ghc-pkg list --global > tmp`
 2. Feed this to `pack_pkg_list`: `./pack_pkg_list.hs tmp`
 3. Insert the output of `pkg_pkg_list` into `pkg_versions.txt`
-4. Manually add the `Win32` version at the top of `pkg_versions.txt`
-5. Use `mk_pkg_table` to generate the table: `./mk_pkg_table.hs < pkg_versions.txt`
-
-Don't forget to do this on a Windows machine as well to get the `Win32` version.
+4. Run `./get_win32_version.sh $GHC_VERSION`, e.g. `./get_win32_version.sh 8.6.4` or `.get_win32_version.sh $(ghc --numeric-version)`.
+5. Add the output of `get_win32_version.sh` to the other `Win32` versions at the top of `pkg_versions.txt`
+6. Use `mk_pkg_table` to generate the table: `./mk_pkg_table.hs < pkg_versions.txt`

--- a/library-versions/get_win32_version.sh
+++ b/library-versions/get_win32_version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+ghc_version="$1"
+
+get_win32_version() {
+    curl --silent "https://downloads.haskell.org/~ghc/${ghc_version}/ghc-${ghc_version}-src.tar.xz" \
+        | tar xJf - "ghc-${ghc_version}/libraries/Win32/Win32.cabal" -O \
+        | sed -n "s/^[vV]ersion:\s\+\(\w\+\)/\1/p"
+}
+
+echo "${ghc_version}   Win32/$(get_win32_version)"


### PR DESCRIPTION
Downloading a full source tarball just to get at the `Win32` version feels kind of brutish, but it works and it takes only 7 seconds for me, which is still faster than any manual process…