### PR TITLE
library-versions/pkg_versions.txt: Updates for 8.8.2 and HEAD

### DIFF
--- a/library-versions/pkg_versions.txt
+++ b/library-versions/pkg_versions.txt
@@ -34,6 +34,7 @@
 8.6.4   Win32/2.6.1.0
 8.6.5   Win32/2.6.1.0
 8.8.1   Win32/2.6.1.0
+8.8.2   Win32/2.6.1.0
 HEAD    Win32/2.6.1.0
 
 ############################################
@@ -97,8 +98,9 @@ HEAD    Win32/2.6.1.0
 # GHC 8.8.x
 
 8.8.1   Cabal/3.0.0.0 array/0.5.4.0 base/4.13.0.0 binary/0.8.7.0 bytestring/0.10.9.0 containers/0.6.2.1 deepseq/1.4.4.0 directory/1.3.3.2 filepath/1.4.2.1 ghc/8.8.1* ghc-boot/8.8.1 ghc-boot-th/8.8.1 ghc-compact/0.1.0.0 ghc-heap/8.8.1 ghc-prim/0.5.3 ghci/8.8.1 haskeline/0.7.5.0 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.8.1 mtl/2.2.2 parsec/3.1.14.0 pretty/1.1.3.6 process/1.6.5.1 rts/1.0 stm/2.5.0.0 template-haskell/2.15.0.0 terminfo/0.4.1.4 text/1.2.4.0 time/1.9.3 transformers/0.5.6.2 unix/2.7.2.2 xhtml/3000.2.2.1
+8.8.2	Cabal/3.0.1.0 array/0.5.4.0 base/4.13.0.0 binary/0.8.7.0 bytestring/0.10.10.0 containers/0.6.2.1 deepseq/1.4.4.0 directory/1.3.4.0 filepath/1.4.2.1 ghc/8.8.2* ghc-boot/8.8.2 ghc-boot-th/8.8.2 ghc-compact/0.1.0.0 ghc-heap/8.8.2 ghc-prim/0.5.3 ghci/8.8.2 haskeline/0.7.5.0 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.8.2 mtl/2.2.2 parsec/3.1.14.0 pretty/1.1.3.6 process/1.6.7.0 rts/1.0 stm/2.5.0.0 template-haskell/2.15.0.0 terminfo/0.4.1.4 text/1.2.4.0 time/1.9.3 transformers/0.5.6.2 unix/2.7.2.2 xhtml/3000.2.2.1
 
 ############################################
 # GHC HEAD
 
-HEAD    Cabal/3.0.0.0 array/0.5.4.0 base/4.13.0.0 binary/0.8.7.0 bytestring/0.10.9.0 containers/0.6.2.1 deepseq/1.4.4.0 directory/1.3.3.2 filepath/1.4.2.1 ghc/8.9* ghc-boot/8.9* ghc-boot-th/8.9* ghc-compact/0.1.0.0 ghc-heap/8.9* ghc-prim/0.6.1 ghci/8.9* haskeline/0.7.5.0 hpc/0.6.0.3 integer-gmp/1.0.2.0 libiserv/8.9* mtl/2.2.2 parsec/3.1.14.0 pretty/1.1.3.6 process/1.6.5.1 stm/2.5.0.0 template-haskell/2.16.0.0 terminfo/0.4.1.4 text/1.2.3.1 time/1.9.3 transformers/0.5.6.2 unix/2.7.2.2 xhtml/3000.2.2.1
+HEAD	Cabal/3.2.0.0 array/0.5.4.0 base/4.14.0.0 binary/0.8.7.0 bytestring/0.10.9.0 containers/0.6.2.1 deepseq/1.4.4.0 directory/1.3.4.0 exceptions/0.10.3 filepath/1.4.2.1 ghc/8.11.0.20200127* ghc-boot/8.11.0.20200127 ghc-boot-th/8.11.0.20200127 ghc-compact/0.1.0.0 ghc-heap/8.11.0.20200127 ghc-prim/0.6.1 ghci/8.11.0.20200127 haskeline/0.8.0.1 hpc/0.6.1.0 integer-gmp/1.0.2.0 libiserv/8.11.0.20200127 mtl/2.2.2 parsec/3.1.14.0 pretty/1.1.3.6 process/1.6.6.0 rts/1.0 stm/2.5.0.0 template-haskell/2.16.0.0 terminfo/0.4.1.4 text/1.2.3.1 time/1.9.3 transformers/0.5.6.2 unix/2.7.2.2


### PR DESCRIPTION
I have updated the wiki page too: https://gitlab.haskell.org/ghc/ghc/wikis/commentary/libraries/version-history